### PR TITLE
Fix `push_ascii` when the current index is unaligned with a byte

### DIFF
--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -512,15 +512,12 @@ impl SeqVec for PackedSeqVec {
 
         let unaligned = core::cmp::min(start_aligned - start, len);
         if unaligned > 0 {
-            // self.seq cannot be empty when start_aligned > start
-            let mut packed_byte = unsafe { *self.seq.last().unwrap_unchecked() };
+            let mut packed_byte = *self.seq.last().unwrap();
             for &base in &seq[..unaligned] {
                 packed_byte |= pack_char(base) << ((self.len % 4) * 2);
                 self.len += 1;
             }
-            unsafe {
-                *self.seq.last_mut().unwrap_unchecked() = packed_byte;
-            }
+            *self.seq.last_mut().unwrap() = packed_byte;
         }
 
         #[allow(unused)]

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -547,7 +547,7 @@ impl SeqVec for PackedSeqVec {
                 packed_byte = 0;
             }
         }
-        if self.len % 4 != 0 {
+        if self.len % 4 != 0 && last < len {
             self.seq.push(packed_byte);
         }
         start..start + len

--- a/src/test.rs
+++ b/src/test.rs
@@ -132,22 +132,24 @@ fn push_ascii_unaligned() {
 
 #[test]
 fn push_ascii_random() {
-    let seq = AsciiSeqVec::random(110).into_raw();
-    let mut packed = PackedSeqVec::default();
-    let mut rng = rand::rng();
-    while packed.len < 100 {
-        let push_len = rng.random_range(1..=8);
-        let range = packed.len..(packed.len + push_len);
-        let range2 = packed.push_ascii(&seq[range.clone()]);
-        assert_eq!(range, range2);
+    for _ in 0..20 {
+        let seq = AsciiSeqVec::random(110).into_raw();
+        let mut packed = PackedSeqVec::default();
+        let mut rng = rand::rng();
+        while packed.len < 100 {
+            let push_len = rng.random_range(1..=8);
+            let range = packed.len..(packed.len + push_len);
+            let range2 = packed.push_ascii(&seq[range.clone()]);
+            assert_eq!(range, range2);
+        }
+        let slice = packed.as_slice();
+        for (i, &c) in seq.iter().take(100).enumerate() {
+            assert_eq!(slice.get_ascii(i), c);
+        }
+        let packed2 = PackedSeqVec::from_ascii(&seq[..packed.len]);
+        let expected = packed2.as_slice();
+        assert!(slice.eq(&expected));
     }
-    let slice = packed.as_slice();
-    for (i, &c) in seq.iter().take(100).enumerate() {
-        assert_eq!(slice.get_ascii(i), c);
-    }
-    let packed2 = PackedSeqVec::from_ascii(&seq[..packed.len]);
-    let expected = packed2.as_slice();
-    assert!(slice.eq(&expected));
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -131,6 +131,26 @@ fn push_ascii_unaligned() {
 }
 
 #[test]
+fn push_ascii_random() {
+    let seq = AsciiSeqVec::random(110).into_raw();
+    let mut packed = PackedSeqVec::default();
+    let mut rng = rand::rng();
+    while packed.len < 100 {
+        let push_len = rng.random_range(1..=8);
+        let range = packed.len..(packed.len + push_len);
+        let range2 = packed.push_ascii(&seq[range.clone()]);
+        assert_eq!(range, range2);
+    }
+    let slice = packed.as_slice();
+    for (i, &c) in seq.iter().take(100).enumerate() {
+        assert_eq!(slice.get_ascii(i), c);
+    }
+    let packed2 = PackedSeqVec::from_ascii(&seq[..packed.len]);
+    let expected = packed2.as_slice();
+    assert!(slice.eq(&expected));
+}
+
+#[test]
 fn iter_bp() {
     let seq = b"ACGTAACCGGTTAAACCCGGGTTTAAAAAAAAACGT";
     for len in 0..=seq.len() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -111,6 +111,26 @@ fn packed_ord() {
 }
 
 #[test]
+fn push_ascii_unaligned() {
+    let seq = b"TCGGCTCGTTCC";
+    let mut packed = PackedSeqVec::default();
+    let range = packed.push_ascii(&seq[..3]);
+    assert_eq!(range, (0..3));
+    let range = packed.push_ascii(&seq[3..9]);
+    assert_eq!(range, (3..9));
+    let range = packed.push_ascii(&seq[9..]);
+    assert_eq!(range, (9..12));
+    assert_eq!(packed.len, seq.len());
+    let slice = packed.as_slice();
+    for (i, &c) in seq.iter().enumerate() {
+        assert_eq!(slice.get_ascii(i), c);
+    }
+    let packed2 = PackedSeqVec::from_ascii(seq);
+    let expected = packed2.as_slice();
+    assert!(slice.eq(&expected));
+}
+
+#[test]
 fn iter_bp() {
     let seq = b"ACGTAACCGGTTAAACCCGGGTTTAAAAAAAAACGT";
     for len in 0..=seq.len() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -142,6 +142,14 @@ fn iter_bp() {
         let packed = packed.as_slice().iter_bp().collect::<Vec<_>>();
         assert_eq!(ascii, packed);
     }
+    let ascii = AsciiSeqVec::from_ascii(seq);
+    let packed = PackedSeqVec::from_ascii(seq);
+    let len = seq.len();
+    for offset in 0..len {
+        let ascii = ascii.slice(offset..len).iter_bp().collect::<Vec<_>>();
+        let packed = packed.slice(offset..len).iter_bp().collect::<Vec<_>>();
+        assert_eq!(ascii, packed);
+    }
 }
 
 #[test]


### PR DESCRIPTION
The current behavior is to push to a new byte regardless of the current length, which is incorrect if the length is not a multiple of 4. In this case, we should fill the remaining bits first.