### PR TITLE
Faster random seq generation using rand_xoshiro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,6 @@ dependencies = [
  "mem_dbg",
  "pyo3",
  "rand",
- "rand_xoshiro",
  "wide",
 ]
 
@@ -404,15 +403,6 @@ checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom",
  "zerocopy 0.8.14",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "mem_dbg",
  "pyo3",
  "rand",
+ "rand_xoshiro",
  "wide",
 ]
 
@@ -403,6 +404,15 @@ checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom",
  "zerocopy 0.8.14",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ description = "Constructing and iterating packed DNA sequences using SIMD"
 
 [dependencies]
 wide = "0.7.32"
-rand = "0.9.0"
-rand_xoshiro = "0.7.0"
+rand = { version = "0.9", features = ["small_rng"] }
 mem_dbg = "0.2.4"
 cfg-if = "1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "Constructing and iterating packed DNA sequences using SIMD"
 [dependencies]
 wide = "0.7.32"
 rand = "0.9.0"
+rand_xoshiro = "0.7.0"
 mem_dbg = "0.2.4"
 cfg-if = "1.0.0"
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -275,7 +275,7 @@ impl SeqVec for Vec<u8> {
 
     fn random(n: usize) -> Self {
         let mut seq = vec![0; n];
-        rand_xoshiro::Xoshiro512StarStar::from_os_rng().fill_bytes(&mut seq);
+        rand::rngs::SmallRng::from_os_rng().fill_bytes(&mut seq);
         seq
     }
 }

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -274,7 +274,8 @@ impl SeqVec for Vec<u8> {
     }
 
     fn random(n: usize) -> Self {
-        let mut rng = rand::rng();
-        (0..n).map(|_| rng.random::<u8>()).collect()
+        let mut seq = vec![0; n];
+        rand_xoshiro::Xoshiro512StarStar::from_os_rng().fill_bytes(&mut seq);
+        seq
     }
 }

--- a/src/ascii_seq.rs
+++ b/src/ascii_seq.rs
@@ -383,7 +383,7 @@ impl SeqVec for AsciiSeqVec {
 
     fn random(n: usize) -> Self {
         let mut seq = vec![0; n];
-        rand_xoshiro::Xoshiro512StarStar::from_os_rng().fill_bytes(&mut seq);
+        rand::rngs::SmallRng::from_os_rng().fill_bytes(&mut seq);
         Self {
             seq: seq.into_iter().map(|b| b"ACGT"[b as usize % 4]).collect(),
         }

--- a/src/ascii_seq.rs
+++ b/src/ascii_seq.rs
@@ -382,11 +382,10 @@ impl SeqVec for AsciiSeqVec {
     }
 
     fn random(n: usize) -> Self {
-        let mut rng = rand::rng();
+        let mut seq = vec![0; n];
+        rand_xoshiro::Xoshiro512StarStar::from_os_rng().fill_bytes(&mut seq);
         Self {
-            seq: (0..n)
-                .map(|_| b"ACGT"[rng.random::<u8>() as usize % 4])
-                .collect(),
+            seq: seq.into_iter().map(|b| b"ACGT"[b as usize % 4]).collect(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use traits::{Seq, SeqVec};
 // For internal use only.
 use core::{array::from_fn, mem::transmute};
 use mem_dbg::{MemDbg, MemSize};
-use rand::Rng;
+use rand::{Rng, RngCore, SeedableRng};
 use std::{hint::assert_unchecked, ops::Range};
 use wide::u32x8 as S;
 use wide::u64x4;

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -561,7 +561,7 @@ impl SeqVec for PackedSeqVec {
 
     fn random(n: usize) -> Self {
         let mut seq = vec![0; n.div_ceil(4)];
-        rand_xoshiro::Xoshiro512StarStar::from_os_rng().fill_bytes(&mut seq);
+        rand::rngs::SmallRng::from_os_rng().fill_bytes(&mut seq);
         PackedSeqVec { seq, len: n }
     }
 }

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -560,8 +560,8 @@ impl SeqVec for PackedSeqVec {
     }
 
     fn random(n: usize) -> Self {
-        let mut rng = rand::rng();
-        let seq = (0..n.div_ceil(4)).map(|_| rng.random::<u8>()).collect();
+        let mut seq = vec![0; n.div_ceil(4)];
+        rand_xoshiro::Xoshiro512StarStar::from_os_rng().fill_bytes(&mut seq);
         PackedSeqVec { seq, len: n }
     }
 }


### PR DESCRIPTION
The current PRNG is quite slow, this is frustrating when it becomes the slowest part of a benchmark.
Switching to [`rand_xoshiro`](https://crates.io/crates/rand_xoshiro) (based on Blackman & Vigna's Xoshiro) makes it an order of magnitude faster.