### PR TITLE
Add PaddedIt<impl ChunkIt>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.0
+- **Breaking**: Make `delay` passed into `par_iter_bp_delayed` a strong type `Delay(pub usize)` to
+  reduce potential for bugs.
+- **Breaking**: Encapsulate parallel iterators in new `PaddedIt { it, padding: usize }` type with `.map`, `.advance`, and `.collect_into` functions.
+- Make `intrinsics::transpose` public for use in `collect_and_dedup` in `simd_minimizers`.
+
 ## 3.2.1
 - Add `Seq::read_{revcomp}_kmer_u128` with more tests
 - Fix bug in `revcomp_u128`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +181,15 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "libc"
@@ -286,6 +301,7 @@ version = "3.2.1"
 dependencies = [
  "cfg-if",
  "epserde",
+ "itertools",
  "mem_dbg",
  "pyo3",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,12 +78,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,15 +175,6 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "libc"
@@ -301,7 +286,6 @@ version = "3.2.1"
 dependencies = [
  "cfg-if",
  "epserde",
- "itertools",
  "mem_dbg",
  "pyo3",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ epserde = { version = "0.8", optional = true }
 
 # Optional pyclass atrributes for some objects.
 pyo3 = { version = "0.25", features = ["extension-module"], optional = true }
+itertools = "0.14.0"
 
 [features]
 # Also needed for tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ epserde = { version = "0.8", optional = true }
 
 # Optional pyclass atrributes for some objects.
 pyo3 = { version = "0.25", features = ["extension-module"], optional = true }
-itertools = "0.14.0"
 
 [features]
 # Also needed for tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ pyo3 = { version = "0.25", features = ["extension-module"], optional = true }
 [features]
 # Also needed for tests.
 default = ["rand"]
+
+# Hides the `simd` warnings when neither AVX2 nor NEON is detected.
+scalar = []

--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ crate was developed:
 This library supports AVX2 and NEON instruction sets.
 Make sure to set `RUSTFLAGS="-C target-cpu=native"` when compiling to use the instruction sets available on your architecture.
 
-    RUSTFLAGS="-C target-cpu=native" cargo run --release
+``` sh
+RUSTFLAGS="-C target-cpu=native" cargo run --release
+```
 
+Enable the `-F scalar` feature flag to fall back to a scalar implementation with
+reduced performance.
 
 ## Usage example
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -119,7 +119,7 @@ impl Seq<'_> for &[u8] {
     fn par_iter_bp_delayed(
         self,
         context: usize,
-        delay: usize,
+        Delay(delay): Delay,
     ) -> PaddedIt<impl ChunkIt<(u32x8, u32x8)>> {
         assert!(
             delay < usize::MAX / 2,
@@ -192,8 +192,8 @@ impl Seq<'_> for &[u8] {
     fn par_iter_bp_delayed_2(
         self,
         context: usize,
-        delay1: usize,
-        delay2: usize,
+        Delay(delay1): Delay,
+        Delay(delay2): Delay,
     ) -> PaddedIt<impl ChunkIt<(u32x8, u32x8, u32x8)>> {
         assert!(delay1 <= delay2, "Delay1 must be at most delay2.");
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,4 +1,4 @@
-use crate::{intrinsics::transpose, packed_seq::read_slice, traits::ChunkIt};
+use crate::{intrinsics::transpose, packed_seq::read_slice, padded_it::ChunkIt};
 
 use super::*;
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -71,7 +71,7 @@ impl Seq<'_> for &[u8] {
 
     /// Iter the ASCII characters.
     #[inline(always)]
-    fn iter_bp(self) -> impl ExactSizeIterator<Item = u8> + Clone {
+    fn iter_bp(self) -> impl ExactSizeIterator<Item = u8> {
         self.iter().copied()
     }
 

--- a/src/ascii_seq.rs
+++ b/src/ascii_seq.rs
@@ -1,4 +1,4 @@
-use crate::{intrinsics::transpose, packed_seq::read_slice, traits::ChunkIt};
+use crate::{intrinsics::transpose, packed_seq::read_slice, padded_it::ChunkIt};
 
 use super::*;
 

--- a/src/ascii_seq.rs
+++ b/src/ascii_seq.rs
@@ -240,7 +240,7 @@ impl<'s> Seq<'s> for AsciiSeq<'s> {
     ///
     /// NOTE: This is only efficient on x86_64 with `BMI2` support for `pext`.
     #[inline(always)]
-    fn iter_bp(self) -> impl ExactSizeIterator<Item = u8> + Clone {
+    fn iter_bp(self) -> impl ExactSizeIterator<Item = u8> {
         #[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]
         {
             let mut cache = 0;

--- a/src/ascii_seq.rs
+++ b/src/ascii_seq.rs
@@ -316,7 +316,11 @@ impl<'s> Seq<'s> for AsciiSeq<'s> {
     }
 
     #[inline(always)]
-    fn par_iter_bp_delayed(self, context: usize, delay: usize) -> PaddedIt<impl ChunkIt<(S, S)>> {
+    fn par_iter_bp_delayed(
+        self,
+        context: usize,
+        Delay(delay): Delay,
+    ) -> PaddedIt<impl ChunkIt<(S, S)>> {
         assert!(
             delay < usize::MAX / 2,
             "Delay={} should be >=0.",
@@ -391,8 +395,8 @@ impl<'s> Seq<'s> for AsciiSeq<'s> {
     fn par_iter_bp_delayed_2(
         self,
         context: usize,
-        delay1: usize,
-        delay2: usize,
+        Delay(delay1): Delay,
+        Delay(delay2): Delay,
     ) -> PaddedIt<impl ChunkIt<(S, S, S)>> {
         assert!(delay1 <= delay2, "Delay1 must be at most delay2.");
 

--- a/src/intrinsics/transpose.rs
+++ b/src/intrinsics/transpose.rs
@@ -3,7 +3,7 @@
 use wide::u32x4;
 use wide::u32x8 as S;
 
-/// Transpose a matrix of 8 SIMD vectors.
+/// Transpose an 8x8 matrix of 8 `u32x8` SIMD elements.
 /// <https://stackoverflow.com/questions/25622745/transpose-an-8x8-float-using-avx-avx2>
 // TODO: Investigate other transpose functions mentioned there?
 pub fn transpose(m: [S; 8]) -> [S; 8] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use packed_seq::{
     complement_base, complement_base_simd, complement_char, pack_char, unpack_base,
 };
 pub use packed_seq::{PackedSeq, PackedSeqVec};
-pub use traits::{ChunkIt, Delay, PaddedIt, Seq, SeqVec};
+pub use traits::{Advance, ChunkIt, Delay, PaddedIt, Seq, SeqVec};
 
 // For internal use only.
 use core::array::from_fn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,17 @@
 //! - `epserde` enables `derive(epserde::Epserde)` for `PackedSeqVec` and `AsciiSeqVec`, and adds its `SerializeInner` and `DeserializeInner` traits to `SeqVec`.
 //! - `pyo3` enables `derive(pyo3::pyclass)` for `PackedSeqVec` and `AsciiSeqVec`.
 
+#[cfg(not(any(
+    doc,
+    debug_assertions,
+    target_feature = "avx2",
+    target_feature = "neon",
+    feature = "scalar"
+)))]
+compile_error!(
+    "Packed-seq uses AVX2 or NEON SIMD instructions. Compile using `-C target-cpu=native` to get the expected performance. Silence this error using the `scalar` feature."
+);
+
 /// Functions with architecture-specific implementations.
 pub mod intrinsics {
     mod transpose;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 //! - `pyo3` enables `derive(pyo3::pyclass)` for `PackedSeqVec` and `AsciiSeqVec`.
 
 /// Functions with architecture-specific implementations.
-mod intrinsics {
+pub mod intrinsics {
     mod transpose;
     pub use transpose::transpose;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use packed_seq::{
     complement_base, complement_base_simd, complement_char, pack_char, unpack_base,
 };
 pub use packed_seq::{PackedSeq, PackedSeqVec};
-pub use traits::{PaddedIt, Seq, SeqVec, ChunkIt};
+pub use traits::{ChunkIt, Delay, PaddedIt, Seq, SeqVec};
 
 // For internal use only.
 use core::array::from_fn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ mod traits;
 mod ascii;
 mod ascii_seq;
 mod packed_seq;
+mod padded_it;
 
 #[cfg(test)]
 mod test;
@@ -114,7 +115,8 @@ pub use packed_seq::{
     complement_base, complement_base_simd, complement_char, pack_char, unpack_base,
 };
 pub use packed_seq::{PackedSeq, PackedSeqVec};
-pub use traits::{Advance, ChunkIt, Delay, PaddedIt, Seq, SeqVec};
+pub use padded_it::{Advance, ChunkIt, PaddedIt};
+pub use traits::{Delay, Seq, SeqVec};
 
 // For internal use only.
 use core::array::from_fn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use packed_seq::{
     complement_base, complement_base_simd, complement_char, pack_char, unpack_base,
 };
 pub use packed_seq::{PackedSeq, PackedSeqVec};
-pub use traits::{Seq, SeqVec};
+pub use traits::{PaddedIt, Seq, SeqVec, ChunkIt};
 
 // For internal use only.
 use core::array::from_fn;

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -387,7 +387,11 @@ impl<'s> Seq<'s> for PackedSeq<'s> {
     /// NOTE: When `self` starts does not start at a byte boundary, the
     /// 'delayed' character is not guaranteed to be `0`.
     #[inline(always)]
-    fn par_iter_bp_delayed(self, context: usize, delay: usize) -> PaddedIt<impl ChunkIt<(S, S)>> {
+    fn par_iter_bp_delayed(
+        self,
+        context: usize,
+        Delay(delay): Delay,
+    ) -> PaddedIt<impl ChunkIt<(S, S)>> {
         #[cfg(target_endian = "big")]
         panic!("Big endian architectures are not supported.");
 
@@ -485,8 +489,8 @@ impl<'s> Seq<'s> for PackedSeq<'s> {
     fn par_iter_bp_delayed_2(
         self,
         context: usize,
-        delay1: usize,
-        delay2: usize,
+        Delay(delay1): Delay,
+        Delay(delay2): Delay,
     ) -> PaddedIt<impl ChunkIt<(S, S, S)>> {
         #[cfg(target_endian = "big")]
         panic!("Big endian architectures are not supported.");

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -1,6 +1,6 @@
 use traits::Seq;
 
-use crate::{intrinsics::transpose, traits::ChunkIt};
+use crate::{intrinsics::transpose, padded_it::ChunkIt};
 
 use super::*;
 

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -300,7 +300,7 @@ impl<'s> Seq<'s> for PackedSeq<'s> {
     }
 
     #[inline(always)]
-    fn iter_bp(self) -> impl ExactSizeIterator<Item = u8> + Clone {
+    fn iter_bp(self) -> impl ExactSizeIterator<Item = u8> {
         assert!(self.len <= self.seq.len() * 4);
 
         let this = self.normalize();

--- a/src/padded_it.rs
+++ b/src/padded_it.rs
@@ -1,11 +1,27 @@
+//! FIXME Collect SIMD-iterator values into a flat `Vec<u32>`.
+
 /// Trait alias for iterators over multiple chunks in parallel, typically over `u32x8`.
 pub trait ChunkIt<T>: ExactSizeIterator<Item = T> {}
 impl<T, I: ExactSizeIterator<Item = T>> ChunkIt<T> for I {}
+use crate::intrinsics::transpose;
+use std::mem::transmute;
+use wide::u32x8;
 
 /// An iterator over multiple lanes, with a given amount of padding at the end of the last lane(s).
 pub struct PaddedIt<I> {
     pub it: I,
     pub padding: usize,
+}
+
+pub trait Advance {
+    fn advance(self, n: usize) -> Self;
+}
+impl<I: ExactSizeIterator> Advance for I {
+    #[inline(always)]
+    fn advance(mut self, n: usize) -> Self {
+        self.by_ref().take(n).for_each(drop);
+        self
+    }
 }
 
 impl<I> PaddedIt<I> {
@@ -30,13 +46,52 @@ impl<I> PaddedIt<I> {
     }
 }
 
-pub trait Advance {
-    fn advance(self, n: usize) -> Self;
-}
-impl<I: ExactSizeIterator> Advance for I {
+impl<I: ChunkIt<u32x8>> PaddedIt<I> {
+    /// Convenience wrapper around `collect_into`.
+    pub fn collect(self) -> Vec<u32> {
+        let mut v = vec![];
+        self.collect_into(&mut v);
+        v
+    }
+
+    /// Collect a SIMD-iterator into a single flat vector.
+    /// Works by taking 8 elements from each stream, and transposing this SIMD-matrix before writing out the results.
+    /// The `tail` is appended at the end.
     #[inline(always)]
-    fn advance(mut self, n: usize) -> Self {
-        self.by_ref().take(n).for_each(drop);
-        self
+    pub fn collect_into(self, out_vec: &mut Vec<u32>) {
+        let PaddedIt { it, padding } = self;
+        let len = it.len();
+        out_vec.resize(len * 8, 0);
+
+        let mut m = [unsafe { transmute([0; 8]) }; 8];
+        let mut i = 0;
+        it.for_each(|x| {
+            m[i % 8] = x;
+            if i % 8 == 7 {
+                let t = transpose(m);
+                for j in 0..8 {
+                    unsafe {
+                        *out_vec
+                            .get_unchecked_mut(j * len + 8 * (i / 8)..)
+                            .split_first_chunk_mut::<8>()
+                            .unwrap()
+                            .0 = transmute(t[j]);
+                    }
+                }
+            }
+            i += 1;
+        });
+
+        // Manually write the unfinished parts of length k=i%8.
+        let t = transpose(m);
+        let k = i % 8;
+        for j in 0..8 {
+            unsafe {
+                out_vec[j * len + 8 * (i / 8)..j * len + 8 * (i / 8) + k]
+                    .copy_from_slice(&transmute::<_, [u32; 8]>(t[j])[..k]);
+            }
+        }
+
+        out_vec.resize(out_vec.len() - padding, 0);
     }
 }

--- a/src/padded_it.rs
+++ b/src/padded_it.rs
@@ -1,0 +1,42 @@
+/// Trait alias for iterators over multiple chunks in parallel, typically over `u32x8`.
+pub trait ChunkIt<T>: ExactSizeIterator<Item = T> {}
+impl<T, I: ExactSizeIterator<Item = T>> ChunkIt<T> for I {}
+
+/// An iterator over multiple lanes, with a given amount of padding at the end of the last lane(s).
+pub struct PaddedIt<I> {
+    pub it: I,
+    pub padding: usize,
+}
+
+impl<I> PaddedIt<I> {
+    #[inline(always)]
+    pub fn map<T, T2>(self, f: impl FnMut(T) -> T2) -> PaddedIt<impl ChunkIt<T2>>
+    where
+        I: ChunkIt<T>,
+    {
+        PaddedIt {
+            it: self.it.map(f),
+            padding: self.padding,
+        }
+    }
+
+    #[inline(always)]
+    pub fn advance<T>(mut self, n: usize) -> PaddedIt<impl ChunkIt<T>>
+    where
+        I: ChunkIt<T>,
+    {
+        self.it = self.it.advance(n);
+        self
+    }
+}
+
+pub trait Advance {
+    fn advance(self, n: usize) -> Self;
+}
+impl<I: ExactSizeIterator> Advance for I {
+    #[inline(always)]
+    fn advance(mut self, n: usize) -> Self {
+        self.by_ref().take(n).for_each(drop);
+        self
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -363,7 +363,7 @@ fn par_iter_bp() {
 #[test]
 fn par_iter_bp_delayed0() {
     let s = PackedSeqVec::from_ascii(b"ACGTAACCGGTTAAACCCGGGTTTAAAAAAAAACGT");
-    let PaddedIt { it, padding } = s.as_slice().par_iter_bp_delayed(1, 0);
+    let PaddedIt { it, padding } = s.as_slice().par_iter_bp_delayed(1, Delay(0));
     let it = it.collect::<Vec<_>>();
     fn f(x: &[u8; 8], y: &[u8; 8]) -> (u32x8, u32x8) {
         let x = x.map(|x| pack_char(x) as u32);
@@ -389,7 +389,7 @@ fn par_iter_bp_delayed0() {
 #[test]
 fn par_iter_bp_delayed1() {
     let s = PackedSeqVec::from_ascii(b"ACGTAACCGGTTAAACCCGGGTTTAAAAAAAAACGT");
-    let PaddedIt { it, padding } = s.as_slice().par_iter_bp_delayed(1, 1);
+    let PaddedIt { it, padding } = s.as_slice().par_iter_bp_delayed(1, Delay(1));
     let it = it.collect::<Vec<_>>();
     fn f(x: &[u8; 8], y: &[u8; 8]) -> (u32x8, u32x8) {
         let x = x.map(|x| pack_char(x) as u32);
@@ -501,9 +501,8 @@ fn par_iter_bp_delayed_fuzz() {
 
         // let context = random_range(1..=512.min(len).max(1));
         let context = 1;
-        let delay = random_range(0..512);
-        eprintln!("LEN {len} CONTEXT {context} DELAY {delay}");
-        let PaddedIt{it, padding} = s.par_iter_bp_delayed(context, delay);
+        let delay = Delay(random_range(0..512));
+        let PaddedIt { it, padding } = s.par_iter_bp_delayed(context, delay);
         eprintln!("padding: {padding}");
         let it = it.collect::<Vec<_>>();
         fn f(x: &[u8; 8], y: &[u8; 8]) -> (u32x8, u32x8) {
@@ -539,10 +538,10 @@ fn par_iter_bp_delayed_fuzz() {
                 f(
                     &from_fn(|j| get(seq.0, i + stride * j)),
                     &from_fn(|j| {
-                        if i < delay {
+                        if i < delay.0 {
                             b'A'
                         } else {
-                            get(seq.0, (i + stride * j).wrapping_sub(delay))
+                            get(seq.0, (i + stride * j).wrapping_sub(delay.0))
                         }
                     }),
                 )
@@ -581,7 +580,8 @@ fn par_iter_bp_delayed2_fuzz() {
         let delay = random_range(0..512);
         let delay2 = random_range(delay..=512);
         eprintln!("LEN {len} CONTEXT {context} DELAY {delay}");
-        let PaddedIt { it, padding } = s.par_iter_bp_delayed_2(context, delay, delay2);
+        let PaddedIt { it, padding } =
+            s.par_iter_bp_delayed_2(context, Delay(delay), Delay(delay2));
         eprintln!("padding: {padding}");
         let it = it.collect::<Vec<_>>();
         fn f(x: &[u8; 8], y: &[u8; 8], z: &[u8; 8]) -> (u32x8, u32x8, u32x8) {
@@ -648,7 +648,7 @@ fn par_iter_bp_delayed2_fuzz() {
 #[test]
 fn par_iter_bp_delayed01() {
     let s = PackedSeqVec::from_ascii(b"ACGTAACCGGTTAAACCCGGGTTTAAAAAAAAACGT");
-    let PaddedIt { it, padding } = s.as_slice().par_iter_bp_delayed_2(1, 0, 1);
+    let PaddedIt { it, padding } = s.as_slice().par_iter_bp_delayed_2(1, Delay(0), Delay(1));
     let it = it.collect::<Vec<_>>();
     fn f(x: &[u8; 8], y: &[u8; 8], z: &[u8; 8]) -> (u32x8, u32x8, u32x8) {
         let x = x.map(|x| pack_char(x) as u32);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -37,6 +37,9 @@ impl<I> PaddedIt<I> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Delay(pub usize);
+
 /// A non-owned slice of characters.
 ///
 /// The represented character values are expected to be in `[0, 2^b)`,
@@ -161,7 +164,7 @@ pub trait Seq<'s>: Copy + Eq + Ord {
     fn par_iter_bp_delayed(
         self,
         context: usize,
-        delay: usize,
+        delay: Delay,
     ) -> PaddedIt<impl ChunkIt<(u32x8, u32x8)>>;
 
     /// Iterate over 8 chunks of the sequence in parallel, returning three characters:
@@ -181,8 +184,8 @@ pub trait Seq<'s>: Copy + Eq + Ord {
     fn par_iter_bp_delayed_2(
         self,
         context: usize,
-        delay1: usize,
-        delay2: usize,
+        delay1: Delay,
+        delay2: Delay,
     ) -> PaddedIt<impl ChunkIt<(u32x8, u32x8, u32x8)>>;
 
     /// Compare and return the LCP of the two sequences.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,6 +4,7 @@ use super::u32x8;
 use mem_dbg::{MemDbg, MemSize};
 use std::ops::Range;
 
+/// Strong type indicating the delay passed to [`Seq::par_iter_bp_delayed`] and [`Seq::par_iter_bp_delayed_2`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Delay(pub usize);
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,49 +1,8 @@
+use crate::{ChunkIt, PaddedIt};
+
 use super::u32x8;
 use mem_dbg::{MemDbg, MemSize};
 use std::ops::Range;
-
-/// Trait alias for iterators over multiple chunks in parallel, typically over `u32x8`.
-pub trait ChunkIt<T>: ExactSizeIterator<Item = T> {}
-impl<T, I: ExactSizeIterator<Item = T>> ChunkIt<T> for I {}
-
-/// An iterator over multiple lanes, with a given amount of padding at the end of the last lane(s).
-pub struct PaddedIt<I> {
-    pub it: I,
-    pub padding: usize,
-}
-
-impl<I> PaddedIt<I> {
-    #[inline(always)]
-    pub fn map<T, T2>(self, f: impl FnMut(T) -> T2) -> PaddedIt<impl ChunkIt<T2>>
-    where
-        I: ChunkIt<T>,
-    {
-        PaddedIt {
-            it: self.it.map(f),
-            padding: self.padding,
-        }
-    }
-
-    #[inline(always)]
-    pub fn advance<T>(mut self, n: usize) -> PaddedIt<impl ChunkIt<T>>
-    where
-        I: ChunkIt<T>,
-    {
-        self.it = self.it.advance(n);
-        self
-    }
-}
-
-pub trait Advance {
-    fn advance(self, n: usize) -> Self;
-}
-impl<I: ExactSizeIterator> Advance for I {
-    #[inline(always)]
-    fn advance(mut self, n: usize) -> Self {
-        self.by_ref().take(n).for_each(drop);
-        self
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Delay(pub usize);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -99,7 +99,7 @@ pub trait Seq<'s>: Copy + Eq + Ord {
     }
 
     /// Iterate over the `b`-bit characters of the sequence.
-    fn iter_bp(self) -> impl ExactSizeIterator<Item = u8> + Clone;
+    fn iter_bp(self) -> impl ExactSizeIterator<Item = u8>;
 
     /// Iterate over 8 chunks of `b`-bit characters of the sequence in parallel.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,5 @@
 use super::u32x8;
+use itertools::Itertools;
 use mem_dbg::{MemDbg, MemSize};
 use std::ops::Range;
 
@@ -10,6 +11,30 @@ impl<T, I: ExactSizeIterator<Item = T>> ChunkIt<T> for I {}
 pub struct PaddedIt<I> {
     pub it: I,
     pub padding: usize,
+}
+
+impl<I> PaddedIt<I> {
+    #[inline(always)]
+    pub fn map<T, T2>(self, f: impl FnMut(T) -> T2) -> PaddedIt<impl ChunkIt<T2>>
+    where
+        I: ChunkIt<T>,
+    {
+        PaddedIt {
+            it: self.it.map(f),
+            padding: self.padding,
+        }
+    }
+
+    #[inline(always)]
+    pub fn dropping<T>(self, drop: usize) -> PaddedIt<impl ChunkIt<T>>
+    where
+        I: ChunkIt<T>,
+    {
+        PaddedIt {
+            it: self.it.dropping(drop),
+            padding: self.padding,
+        }
+    }
 }
 
 /// A non-owned slice of characters.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,4 @@
 use super::u32x8;
-use itertools::Itertools;
 use mem_dbg::{MemDbg, MemSize};
 use std::ops::Range;
 
@@ -26,14 +25,23 @@ impl<I> PaddedIt<I> {
     }
 
     #[inline(always)]
-    pub fn dropping<T>(self, drop: usize) -> PaddedIt<impl ChunkIt<T>>
+    pub fn advance<T>(mut self, n: usize) -> PaddedIt<impl ChunkIt<T>>
     where
         I: ChunkIt<T>,
     {
-        PaddedIt {
-            it: self.it.dropping(drop),
-            padding: self.padding,
-        }
+        self.it = self.it.advance(n);
+        self
+    }
+}
+
+pub trait Advance {
+    fn advance(self, n: usize) -> Self;
+}
+impl<I: ExactSizeIterator> Advance for I {
+    #[inline(always)]
+    fn advance(mut self, n: usize) -> Self {
+        self.by_ref().take(n).for_each(drop);
+        self
     }
 }
 


### PR DESCRIPTION
@imartayan 

Not sure this is very nice to use yet (maybe it's better to just not do this at all?)

I think it should be possible to have some more encapsulation around this, where `PaddedIt` over a `u32x8` or `(u32x8, u32x8)` can implement some things that are currently handled downstream, such as collecting into a flat vector for the scalar case.

For most other cases I guess the iterator is transformed and the padding is passed on with some modification. Not sure it all that can nicely be captured in some type of some kind that automagically corrects the padding.